### PR TITLE
Modal for GitHub Username

### DIFF
--- a/_includes/dialog.html
+++ b/_includes/dialog.html
@@ -1,14 +1,16 @@
 <dialog id="gh-name-dialog" aria-labelledby="dialog-title" aria-describedby="dialog-description">
-  <h3 id="dialog-title">Please enter your GitHub username.</h3>
-  <p id="dialog-description">This site uses your GitHub username to create some custom links to project repos.</p>
-  <form method="dialog">
-    <div>
-    <input type="text" id="gh-name-input"/>
+  <div id="dialog-text">
+    <h3 id="dialog-title">Please enter your GitHub username.</h3>
+    <p id="dialog-description">This site uses your GitHub username to create some custom links to project repos.</p>
+  </div>  
+  <form method="dialog" id="gh-username-form">
+    <div class="dialog-field">
+    <label for="gh-name-input"></label>
+    <input type="text" id="gh-name-input" required/>
     </div>
-    <div>
-      <button value="cancel" id="closeDialog">Cancel</button>
-      <button id="confirmBtn" value="default">Confirm</button>
+    <div class="dialog-buttons">
+      <button value="cancel" id="cancel-btn" class="btn btn-outline">Cancel</button>
+      <button id="confirm-btn" class="btn btn-green" value="default" type="submit">Submit</button>
     </div>
   </form>
 </dialog>
-<output></output>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,7 @@ layout: table_wrappers
       </svg>
     </symbol>
   </svg>
-
+{% include dialog.html %}
   <div class="side-bar">
     <div class="site-header">
       <a href="{{ '/' | absolute_url }}" class="site-title lh-tight">{% include title.html %}</a>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -264,3 +264,22 @@ strong {
     // color: $brand-violet;
   }
 }
+
+dialog {
+  border-radius: 4px;
+  border: 1px solid silver;
+  padding: 3rem;
+  .dialog-buttons {
+    margin-top: 3rem;
+  }
+  input {
+    padding: 0.5rem;
+    border: 1px solid silver;
+    border-radius: 4px;
+    width: 80%;
+  }
+}
+
+dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.6);
+}

--- a/assets/js/github-username.js
+++ b/assets/js/github-username.js
@@ -1,18 +1,67 @@
 // To enable project links, we'll ask users for their github username and store it in local storage
 
-let githubUsername = window.localStorage.getItem('ghName')
+const localStorageKey = 'ghName'
+const dialog = document.getElementById('gh-name-dialog')
+const cancelBtn = document.getElementById('cancel-btn')
+const form = document.getElementById('gh-username-form')
+let cancelAttempts = 0
 
-const ensureGHUsername = () => {
+/****** Functions ******/
+const handleSubmit = (e) => {
+  e.preventDefault()
+  const ghNameInput = document.getElementById('gh-name-input')
+  window.localStorage.setItem(localStorageKey, ghNameInput.value)
+  ghNameInput.value = ''
+  dialog.close()
+  createCustomRepoLink()
+}
+
+// run this function once we have a username in localstorage
+function createCustomRepoLink() {
+  let githubUsername = window.localStorage.getItem(localStorageKey)
+  if (!githubUsername) return 
+  const repoLink = document.getElementById('custom-repo-link')
+  if (repoLink) repoLink.href += githubUsername
+}
+
+const openDialog = () => {
+  dialog.showModal()
+}
+
+const showWarning = () => {
+  const dialogTextDiv = document.getElementById('dialog-text')
+  let warning = document.getElementById('dialog-warning')
+  if (warning) dialogTextDiv.removeChild(warning)
+  const githubUsername = window.localStorage.getItem(localStorageKey)
   if (!githubUsername) {
-    githubUsername = window.prompt(
-      'Please enter your GitHub username. \n\n This site uses it to generate personalized project links. \n\n If you dismiss this prompt, it will keep appearing until you enter your information. 😀',
-      ''
-    )
-    window.localStorage.setItem('ghName', githubUsername.trim())
+    warning = document.createElement('p')
+    warning.id = 'dialog-warning'
+    warning.style.color = '#c9184a'
+    warning.innerText =
+      "If you don't set a GitHub username, some project links might not work properly."
+    dialogTextDiv.appendChild(warning)
   }
 }
 
-const repoLink = document.getElementById('custom-repo-link')
-if (repoLink) repoLink.href += githubUsername
+const closeDialog = (event) => {
+  event.preventDefault()
+  if (cancelAttempts) dialog.close()
+  cancelAttempts = 1
+  showWarning()
+}
 
-window.addEventListener('load', () => ensureGHUsername())
+
+/****** Event Listeners ******/
+window.addEventListener('load', () => {
+  const githubUsername = window.localStorage.getItem(localStorageKey)
+  if (!githubUsername) {
+    console.log('No github username')
+    openDialog()
+  } else {
+    createCustomRepoLink()
+  }
+})
+
+cancelBtn.addEventListener('click', closeDialog)
+
+form.addEventListener('submit', handleSubmit)


### PR DESCRIPTION
This PR replaces the existing window prompt for a github username with a JavaScript modal, implemented with an HTML `dialog` element.

<img width="1052" alt="Screen Shot 2023-03-13 at 4 58 00 PM" src="https://user-images.githubusercontent.com/7226152/224830702-9a142dff-8205-4b24-927a-329975cea5b4.png">


Github usernames are stored only in local storage and used to create some project links for front end projects. Used in conjunction with the Repobee feature to create repos, this replaces the need for GitHub classroom assignment links. For now the project links for front end will be generated this way, but anyone who loads the page will be prompted for their github username. 

If the modal is dismissed without entering a username, a warning will show indicating that project links may not work, but on the second try the modal will close. However, it will appear again upon any new page reload; navigating to any page will cause a page reload.

This feature will likely need small fixes, but I anticipate those will be confined to front end pages that are using the code to generate links.